### PR TITLE
Added exports to point to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
   "files": [
     "./dist"
   ],
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.js"
+    }
+  },
   "keywords": [],
   "author": "",
   "license": "GPL-3.0-only",


### PR DESCRIPTION
I added an exports section to the package.json file so that node can locate the files inside the dist folder, without us having to manually move all the files up one level.